### PR TITLE
Ability to cancel future events on return false

### DIFF
--- a/selector-listeners.js
+++ b/selector-listeners.js
@@ -9,7 +9,7 @@
 		startEvent = function(event){
 			event.selector = (events[event.animationName] || {}).selector;
 			((this.selectorListeners || {})[event.animationName] || []).forEach(function(fn){
-				fn.call(this, event);
+				if (fn.call(this, event) === false) this.removeSelectorListener(event.selector, fn);
 			}, this);
 		},
 		prefix = (function() {


### PR DESCRIPTION
Primary use is to listen to first match on comma separated selectors.