### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SelectorListener
 
 Provides the following document/element methods to enable listening for CSS selector rule matches:
 
-###The Basics###
+### The Basics ###
 
 ```javascript
 
@@ -23,7 +23,7 @@ document.getElementById('foo').removeSelectorListener('.one + .two + .three', on
 
 ```
 
-###Now let's get fancy:###
+### Now let's get fancy: ###
 
 ```javascript
 

--- a/license.md
+++ b/license.md
@@ -1,5 +1,5 @@
 
-###SelectorListener is available under Apache 2###
+### SelectorListener is available under Apache 2 ###
 
 Copyright 2012 Daniel Buchner
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
